### PR TITLE
Fix test query on many records

### DIFF
--- a/src/main/kotlin/no/nav/sf/nada/gui/Gui.kt
+++ b/src/main/kotlin/no/nav/sf/nada/gui/Gui.kt
@@ -10,12 +10,12 @@ import mu.KotlinLogging
 import no.nav.sf.nada.HttpCalls.doSFQuery
 import no.nav.sf.nada.Metrics
 import no.nav.sf.nada.TableDef
-import no.nav.sf.nada.addLimitRestriction
 import no.nav.sf.nada.addYesterdayRestriction
 import no.nav.sf.nada.application
 import no.nav.sf.nada.bulk.BulkOperation
 import no.nav.sf.nada.bulk.OperationInfo
 import no.nav.sf.nada.gson
+import no.nav.sf.nada.removeWhatIdAndWhoId
 import no.nav.sf.nada.token.AccessTokenHandler
 import org.http4k.core.HttpHandler
 import org.http4k.core.Request
@@ -52,7 +52,7 @@ object Gui {
         var yesterday = 0
         var total = 0
 
-        val responseTotal = doSFQuery("${AccessTokenHandler.instanceUrl}${application.sfQueryBase}${query.addLimitRestriction()}")
+        val responseTotal = doSFQuery("${AccessTokenHandler.instanceUrl}${application.sfQueryBase}${query.removeWhatIdAndWhoId()}")
         File("/tmp/responseAtTotalCall").writeText(responseTotal.toMessage())
         if (responseTotal.status.code == 400) {
             result += "Bad request: " + responseTotal.bodyString()
@@ -72,9 +72,9 @@ object Gui {
                 File("/tmp/exceptionAtTotalCall").writeText(e.toString() + "\n" + e.stackTraceToString())
             }
         }
-        val responseDate = doSFQuery("${AccessTokenHandler.instanceUrl}${application.sfQueryBase}${queryYesterday.addLimitRestriction()}")
+        val responseDate = doSFQuery("${AccessTokenHandler.instanceUrl}${application.sfQueryBase}${queryYesterday.removeWhatIdAndWhoId()}")
         File("/tmp/responseAtDateCall").writeText(responseDate.toMessage())
-        if (responseTotal.status.code == 400) {
+        if (responseDate.status.code == 400) {
             result += "\nBad request: " + responseDate.bodyString()
             File("/tmp/badRequestAtDateCall").writeText(responseDate.bodyString())
             success = false

--- a/src/main/kotlin/no/nav/sf/nada/utils.kt
+++ b/src/main/kotlin/no/nav/sf/nada/utils.kt
@@ -90,20 +90,6 @@ fun String.addLimitRestriction(maxRecords: Int = 1000): String {
     return "$this$connector+$maxRecords"
 }
 
-fun String.removeWhatIdAndWhoId(): String {
-    // Decode the query to manipulate it as a plain text string
-    val decodedQuery = java.net.URLDecoder.decode(this, "UTF-8")
-
-    // Regex to match `WhatId` and `WhoId` fields in the SELECT clause
-    val regex = Regex("\\b(WhatId|WhoId)\\b,?\\s*")
-
-    // Replace matches with an empty string
-    val updatedQuery = decodedQuery.replace(regex, "")
-
-    // Re-encode the query to make it URL-safe again
-    return java.net.URLEncoder.encode(updatedQuery, "UTF-8")
-}
-
 fun String.addNotRecordsFromTodayRestriction(): String {
     val connector = if (this.contains("WHERE")) "+AND" else "+WHERE"
     return this + "$connector+LastModifiedDate<TODAY"

--- a/src/main/kotlin/no/nav/sf/nada/utils.kt
+++ b/src/main/kotlin/no/nav/sf/nada/utils.kt
@@ -90,6 +90,20 @@ fun String.addLimitRestriction(maxRecords: Int = 1000): String {
     return "$this$connector+$maxRecords"
 }
 
+fun String.removeWhatIdAndWhoId(): String {
+    // Decode the query to manipulate it as a plain text string
+    val decodedQuery = java.net.URLDecoder.decode(this, "UTF-8")
+
+    // Regex to match `WhatId` and `WhoId` fields in the SELECT clause
+    val regex = Regex("\\b(WhatId|WhoId)\\b,?\\s*")
+
+    // Replace matches with an empty string
+    val updatedQuery = decodedQuery.replace(regex, "")
+
+    // Re-encode the query to make it URL-safe again
+    return java.net.URLEncoder.encode(updatedQuery, "UTF-8")
+}
+
 fun String.addNotRecordsFromTodayRestriction(): String {
     val connector = if (this.contains("WHERE")) "+AND" else "+WHERE"
     return this + "$connector+LastModifiedDate<TODAY"


### PR DESCRIPTION
Limit 1000 fungerte ej for å ikke få OPERATION TO LARGE på test query. Om testcall for yesterday innehåller > 100 records så førmodar vi 1000+ records total å utfør ikke en større query (så vi får ett grønt svar - poengen er bare å testa om man kan få ut records med testquery)